### PR TITLE
Add ability to sign plugin internals

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.util.zip.ZipFile
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.intellij.platform.gradle.Constants
@@ -80,10 +81,35 @@ val dotNetSdkPath by lazy {
     return@lazy path
 }
 
+val pluginStagingDir = layout.buildDirectory.dir("plugin-staging").get().asFile
+val pluginStagingContentDir = file("${pluginStagingDir}/${rootProject.name}")
+val signingManifestFile = file("${pluginStagingDir}/files-to-sign.txt")
+
+// All .NET files to include in the plugin
+val dotNetOutputFiles = listOf(
+    "${dotNetPluginId}.dll",
+    "${dotNetPluginId}.pdb",
+    "${yamlParsingId}.dll",
+    "${yamlParsingId}.pdb",
+)
+
+// .NET files that need signing — only our own code
+val dotNetFilesToSign = listOf(
+    "${dotNetPluginId}.dll",
+    "${yamlParsingId}.dll",
+)
+
+// JAR files that need signing
+val jarFilesToSign = buildList {
+    add("${rootProject.name}-${version}.jar")
+    if (intellijPlatform.buildSearchableOptions.get()) {
+        add("${rootProject.name}-${version}-searchableOptions.jar")
+    }
+}
+
 tasks.withType<RunIdeTask>().configureEach {
     jvmArgs("-Didea.reset.classpath.from.manifest=true")
 }
-
 
 // Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
 changelog {
@@ -255,15 +281,10 @@ tasks {
             .resolve(dotNetPluginId)
             .resolve(buildConfigurationProp)
 
-        val dllFiles = listOf(
-            File(outputFolder, "$dotNetPluginId.dll"),
-            File(outputFolder, "$dotNetPluginId.pdb"),
-            File(outputFolder, "$yamlParsingId.dll"),
-            File(outputFolder, "$yamlParsingId.pdb")
-        )
-
-        from(dllFiles) {
-            into("${rootProject.name}/dotnet")
+        dotNetOutputFiles.forEach { fileName ->
+            from(File(outputFolder, fileName)) {
+                into("${rootProject.name}/dotnet")
+            }
         }
 
         from(copyDocs) {
@@ -271,8 +292,140 @@ tasks {
         }
 
         doLast {
-            dllFiles.forEach { file ->
+            dotNetOutputFiles.forEach { fileName ->
+                val file = File(outputFolder, fileName)
                 if (!file.exists()) throw RuntimeException("File $file does not exist")
+            }
+        }
+    }
+
+    // ========= Two-Phase Build for Signing Support ================
+
+    // Preparation for plugin internals signing. Build all JARs and put them into ${pluginStagingDir}
+    val preparePluginInternalsForSigning by registering(Sync::class) {
+        description = "Prepares plugin files for signing and generates signing manifest"
+        group = "build"
+
+        // Source 1: Copy the full plugin directory from prepareSandbox
+        from(prepareSandbox.map { it.pluginDirectory })
+
+        // Source 2: Copy searchable options JAR to lib/ (when enabled)
+        if (intellijPlatform.buildSearchableOptions.get()) {
+            from(jarSearchableOptions.map { it.archiveFile }) {
+                into("lib")
+            }
+        }
+
+        // Destination: the plugin content directory inside staging
+        into(pluginStagingContentDir)
+
+        // Capture script-level vals into locals to avoid capturing the build script in doLast
+        val signingManifestFile = signingManifestFile
+        val pluginStagingDir = pluginStagingDir
+        val jarFilesToSign = jarFilesToSign
+        val dotNetFilesToSign = dotNetFilesToSign
+        val projectName = rootProject.name
+
+        // After syncing, generate the signing manifest
+        doLast {
+            val filesToSign = mutableListOf<String>()
+
+            // Add JAR files that need signing
+            jarFilesToSign.forEach { jarName ->
+                filesToSign.add("${projectName}/lib/${jarName}")
+            }
+
+            // Add .NET files that need signing
+            dotNetFilesToSign.forEach { fileName ->
+                filesToSign.add("${projectName}/dotnet/${fileName}")
+            }
+
+            // Write manifest
+            signingManifestFile.writeText(filesToSign.joinToString("\n"))
+
+            // Summary
+            println("Plugin prepared for signing: ${pluginStagingDir}")
+            println("Signing manifest: ${signingManifestFile}")
+            println("Files to sign: ${filesToSign.size}")
+            filesToSign.forEach { println("  - $it") }
+        }
+    }
+
+    // Validates that ${pluginStagingDir} has all required files to assemble the plugin
+    val validatePluginStaging by registering {
+        description = "Validates that plugin staging directory exists and contains required files"
+        group = "build"
+
+        // Capture script-level vals into locals to avoid capturing the build script in doLast
+        val pluginStagingContentDir = pluginStagingContentDir
+        val dotNetOutputFiles = dotNetOutputFiles
+        val jarFilesToSign = jarFilesToSign
+
+        doLast {
+            if (!pluginStagingContentDir.exists()) {
+                throw RuntimeException(
+                    "Plugin staging directory not found: ${pluginStagingContentDir}\n" +
+                    "Run './gradlew preparePluginInternalsForSigning' first."
+                )
+            }
+
+            // Validate expected .NET output files exist
+            dotNetOutputFiles.forEach { fileName ->
+                val file = pluginStagingContentDir.resolve("dotnet/${fileName}")
+                if (!file.exists()) throw RuntimeException("Expected .NET file not found: ${file}")
+            }
+
+            // Validate expected JAR files exist
+            jarFilesToSign.forEach { jarName ->
+                val file = pluginStagingContentDir.resolve("lib/${jarName}")
+                if (!file.exists()) throw RuntimeException("Expected JAR file not found: ${file}")
+            }
+        }
+    }
+
+    // Assembles the final zip-archive from staged (potentially externally signed) files.
+    // Produces a ZIP with "-from-staging" suffix by default (override with -PoutputPluginFileSuffix=<value>)
+    // Can be used in pipeline: preparePluginInternalsForSigning -> external sign -> assemblePlugin
+    val assemblePlugin by registering(Zip::class) {
+        description = "Assembles the plugin ZIP from staged files with '-from-staging' classifier"
+        group = "build"
+
+        dependsOn(validatePluginStaging)
+
+        from(pluginStagingDir)
+        include("${rootProject.name}/**")
+        exclude("files-to-sign.txt")
+
+        archiveBaseName.convention(intellijPlatform.projectName)
+        archiveClassifier.set(providers.gradleProperty("outputPluginFileSuffix").orElse("from-staging"))
+        destinationDirectory.set(layout.buildDirectory.dir("distributions"))
+    }
+
+    // ==============================================================
+
+    // buildPlugin keeps its default Zip behavior (sources from prepareSandbox + jarSearchableOptions).
+    // We add dependsOn(preparePluginInternalsForSigning) to ensure the staging directory is populated,
+    // then verify the archive matches the staging directory.
+    buildPlugin {
+        dependsOn(preparePluginInternalsForSigning)
+
+        val pluginStagingContentDir = pluginStagingContentDir
+        val projectName = rootProject.name
+
+        doLast {
+            // Verify the archive matches the staging directory to be sure that
+            // buildPlugin and preparePluginInternalsForSigning+assemblePlugin produces the same results
+            val zipFiles = ZipFile(archiveFile.get().asFile).use {
+                it.entries().asSequence().filterNot { e -> e.isDirectory }.map { e -> e.name }.sorted().toList()
+            }
+            val stagingFiles = pluginStagingContentDir.walkTopDown().filter { it.isFile }
+                .map { "${projectName}/${it.relativeTo(pluginStagingContentDir).path.replace('\\', '/')}" }
+                .sorted().toList()
+
+            check(zipFiles == stagingFiles) {
+                "Plugin archive and staging directory are out of sync!\n" +
+                "  Only in archive: ${zipFiles - stagingFiles.toSet()}\n" +
+                "  Only in staging: ${stagingFiles - zipFiles.toSet()}"
             }
         }
     }

--- a/src/dotnet/RiderPlugin.EnhancedUnrealEngineDocumentation/DocumentationProviderComponent.cs
+++ b/src/dotnet/RiderPlugin.EnhancedUnrealEngineDocumentation/DocumentationProviderComponent.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using JetBrains.Application;
 using JetBrains.Application.Environment;
+using JetBrains.Application.Environment.DeployedPackages;
 using JetBrains.Util;
 using JetBrains.Util.Logging;
 using YamlDocsParsing;


### PR DESCRIPTION
Summary:
  - Add `preparePluginInternalsForSigning` task that stages all plugin files and generates a `files-to-sign.txt` manifest
  for external signing
  - Add `assemblePlugin` tasks to validate and package staged (potentially signed) files
  - Reconfigure `buildPlugin` to validate its output matches the staging directory

In this plugin, I didn't override the `buildPlugin` task via `preparePluginInternalsForSigning` and `assemblePlugin` tasks, since `intellij-platform-gradle-plugin` also provides tasks for signing the archive itself and for publishing. And these tasks are strictly depends on `buildPlugin`. My attempts to unwire tasks led to a large amount of hard to support code, that's why I decided to keep `buildPlugin` without significant changes